### PR TITLE
feat(charts): update ingress apiVersion

### DIFF
--- a/charts/brigade-github-gateway/templates/receiver/ingress.yaml
+++ b/charts/brigade-github-gateway/templates/receiver/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.receiver.ingress.enabled }}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1beta1
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
@@ -19,6 +19,19 @@ spec:
   - host: {{ .Values.receiver.host }}
     http:
       paths:
+      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      - pathType: ImplementationSpecific
+        path: /
+        backend:
+          service:
+            name: {{ include "gateway.receiver.fullname" . }}
+            port:
+              {{- if .Values.receiver.tls.enabled }}
+              number: 443
+              {{- else }}
+              number: 80
+              {{- end }}
+      {{- else }}
       - backend:
           serviceName: {{ include "gateway.receiver.fullname" . }}
           {{- if .Values.receiver.tls.enabled }}
@@ -26,6 +39,7 @@ spec:
           {{- else }}
           servicePort: 80
           {{- end }}
+      {{- end}}
   {{- if .Values.receiver.ingress.tls.enabled }}
   tls:
   - hosts:


### PR DESCRIPTION
* Updates the ingress resource in the Brigade chart per deprecation warnings: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

Similar to https://github.com/brigadecore/brigade/pull/1400

Tested via deploy of a dev gateway