### PR TITLE
fix edge publishing

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -113,7 +113,7 @@ async function runSuite(event: Event): Promise<void> {
       buildMonitorJob(event)
     )
   ).run()
-  if (event.worker?.git?.ref == "/refs/heads/master") {
+  if (event.worker?.git?.ref == "master") {
     // Push "edge" images
     await new ConcurrentGroup(
       pushReceiverJob(event),


### PR DESCRIPTION
This fixes a mistake in the `brigade.ts` script. It was looking for ref `/refs/heads/master` as evidence that the check suite was triggered by a merge to master, but the value it _should_ be checking for is simply `master`.