### PR TITLE
update for brigade v2 beta compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ should adjust this value to match a repository into which you have installed
 your new GitHub App.
 
 ```yaml
-apiVersion: brigade.sh/v2-alpha.5
+apiVersion: brigade.sh/v2-beta
 kind: Project
 metadata:
   id: github-demo
@@ -296,7 +296,7 @@ repository; not when they start watching it. This is a peculiarity of GitHub and
 not a peculiarity of this gateway.)
 
 ```yaml
-apiVersion: brigade.sh/v2-alpha.5
+apiVersion: brigade.sh/v2-beta
 kind: Project
 metadata:
   id: github-demo

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.5
+apiVersion: brigade.sh/v2-beta
 kind: Project
 metadata:
   id: github-demo

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.18.2
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
-	github.com/brigadecore/brigade/sdk/v2 v2.0.0-alpha.5.0.20210614205223-c89ad0ef0260
+	github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-github/v33 v33.0.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloDxZfhMm0xrLXZS8+COSu2bXmEQs=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-alpha.5.0.20210614205223-c89ad0ef0260 h1:BuuzEs84uw06myuo4G2j+fLiXMjwS/pXFDNp9i6e1Ds=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-alpha.5.0.20210614205223-c89ad0ef0260/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1 h1:diVZz6uGMAS2eImx39A15ZRP2eoitiC4TbhcgNVUwIg=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This PR upgrades to the latest Brigade 2 SDK for Go, which will allow this gateway to talk to current and future beta releases of Brigade.