### PR TITLE
Update our own use of Brigade 2

### DIFF
--- a/.brigade/package.json
+++ b/.brigade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brigade-github-gateway-ci-cd",
   "dependencies": {
-    "@brigadecore/brigadier": "^2.0.0-alpha.5"
+    "@brigadecore/brigadier": "^2.0.0-beta.1"
   }
 }

--- a/.brigade/project.yaml
+++ b/.brigade/project.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/brigadecore/brigade/v2/v2/apiserver/schemas/project.json
-apiVersion: brigade.sh/v2-alpha.5
+apiVersion: brigade.sh/v2-beta
 kind: Project
 metadata:
   id: brigade-github-gateway

--- a/.brigade/yarn.lock
+++ b/.brigade/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@brigadecore/brigadier@^2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-alpha.5.tgz#d053d3db78e1828c9b992eadf15eac7ed916943e"
-  integrity sha512-XGWanIOpiiRi46n+yD0B+1hkpnEEPoHEwEn7Ut2gP1i0dK6xC6aWq90flM4Np/k365qjS1CLkLtQIkplVPyVag==
+"@brigadecore/brigadier@^2.0.0-beta.1":
+  version "2.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@brigadecore/brigadier/-/brigadier-2.0.0-beta.1.tgz#8abd9461d445d1d13c83404cec22c16f3cbc2104"
+  integrity sha512-PoDfSAYMpqXyhTP+DBE7B1xHXtCxuW7SCLcH9/yQyr4kgeKxsAyYvy1baQx1G5ujpWcKX4ULmxf7dsJdHPX+3w==
   dependencies:
     "@types/node" "^14.14.11"
 


### PR DESCRIPTION
We've got v2.0.0-beta.1 running in our dogfood cluster. This PR just updates our project definition (for safe keeping; it's already been applied) and, for good measure, uses the latest brigadier as well-- although that's not strictly necessary because the worker will swap in its own alternative brigadier implementation (polyfill) at runtime anyway.