### PR TITLE
refactor authn to use a filter

### DIFF
--- a/receiver/config.go
+++ b/receiver/config.go
@@ -62,13 +62,19 @@ func webhookServiceConfig() (webhooks.ServiceConfig, error) {
 	return config, err
 }
 
-// webhooksHandlerConfig populates configuration for the (HTTP/S) webhook
-// handler from environment variables.
-func webhooksHandlerConfig() (webhooks.HandlerConfig, error) {
-	config := webhooks.HandlerConfig{}
-	var err error
-	config.SharedSecret, err = os.GetRequiredEnvVar("GITHUB_APP_SHARED_SECRET")
-	return config, err
+// signatureVerificationFilterConfig populates configuration for the signature
+// verification filter from environment variables.
+func signatureVerificationFilterConfig() (
+	webhooks.SignatureVerificationFilterConfig,
+	error,
+) {
+	config := webhooks.SignatureVerificationFilterConfig{}
+	sharedSecret, err := os.GetRequiredEnvVar("GITHUB_APP_SHARED_SECRET")
+	if err != nil {
+		return config, err
+	}
+	config.SharedSecret = []byte(sharedSecret)
+	return config, nil
 }
 
 // serverConfig populates configuration for the HTTP/S server from environment

--- a/receiver/internal/webhooks/signature_verification_filter.go
+++ b/receiver/internal/webhooks/signature_verification_filter.go
@@ -1,0 +1,71 @@
+package webhooks
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+
+	libHTTP "github.com/brigadecore/brigade-foundations/http"
+	"github.com/google/go-github/v33/github"
+)
+
+// SignatureVerificationFilterConfig encapsulates configuration for the
+// signature verification based auth filter.
+type SignatureVerificationFilterConfig struct {
+	// SharedSecret is the secret mutually agreed upon by this gateway and the
+	// GitHub App that sends webhooks (events) to this gateway. This secret can be
+	// used to validate the authenticity and integrity of payloads received by
+	// this gateway.
+	SharedSecret []byte
+}
+
+// signatureVerificationFilter is a component that implements the http.Filter
+// interface and can conditionally allow or disallow a request based on the
+// ability to verify the signature of the inbound request.
+type signatureVerificationFilter struct {
+	config SignatureVerificationFilterConfig
+}
+
+// NewSignatureVerificationFilter returns a component that implements the
+// http.Filter interface and can conditionally allow or disallow a request based
+// on the ability to verify the signature of the inbound request.
+func NewSignatureVerificationFilter(
+	config SignatureVerificationFilterConfig,
+) libHTTP.Filter {
+	return &signatureVerificationFilter{
+		config: config,
+	}
+}
+
+func (s *signatureVerificationFilter) Decorate(
+	handle http.HandlerFunc,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// If there is no request body, fail right away or else we'll be staring
+		// down the barrel of a nil pointer dereference.
+		if r.Body == nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		// If we encounter an error reading the request body, we're just going to
+		// roll with it. The empty request body will naturally make the signature
+		// verification algorithm fail.
+		bodyBytes, _ := ioutil.ReadAll(r.Body) // nolint: errcheck
+		r.Body.Close()                         // nolint: errcheck
+		// Replace the request body because the original read was destructive!
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
+		if err := github.ValidateSignature(
+			r.Header.Get("X-Hub-Signature"),
+			bodyBytes,
+			s.config.SharedSecret,
+		); err != nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		// If we get this far, everything checks out. Handle the request.
+		handle(w, r)
+	}
+}

--- a/receiver/internal/webhooks/signature_verification_filter_test.go
+++ b/receiver/internal/webhooks/signature_verification_filter_test.go
@@ -1,0 +1,88 @@
+package webhooks
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSignatureVerificationFilter(t *testing.T) {
+	testConfig := SignatureVerificationFilterConfig{
+		SharedSecret: []byte("foobar"),
+	}
+	filter :=
+		NewSignatureVerificationFilter(testConfig).(*signatureVerificationFilter)
+	require.Equal(t, testConfig, filter.config)
+}
+
+func TestSignatureVerificationFilter(t *testing.T) {
+	testSecret := []byte("foobar")
+	testFilter := &signatureVerificationFilter{
+		config: SignatureVerificationFilterConfig{
+			SharedSecret: testSecret,
+		},
+	}
+	testCases := []struct {
+		name       string
+		setup      func() *http.Request
+		assertions func(handlerCalled bool, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name: "signature cannot be verified",
+			setup: func() *http.Request {
+				bodyBytes := []byte("mr body")
+				req, err :=
+					http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+				require.NoError(t, err)
+				// This is just a completely made up signature
+				req.Header.Add("X-Hub-Signature", "johnhancock")
+				return req
+			},
+			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusForbidden, rr.Code)
+				require.False(t, handlerCalled)
+			},
+		},
+		{
+			name: "signature can be verified",
+			setup: func() *http.Request {
+				bodyBytes := []byte("mr body")
+				req, err :=
+					http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(bodyBytes))
+				require.NoError(t, err)
+				// Compute the signature
+				hasher := hmac.New(sha256.New, testSecret)
+				_, err = hasher.Write(bodyBytes)
+				require.NoError(t, err)
+				// Add the signature to the request
+				req.Header.Add(
+					"X-Hub-Signature",
+					fmt.Sprintf("sha256=%x", hasher.Sum(nil)),
+				)
+				return req
+			},
+			assertions: func(handlerCalled bool, rr *httptest.ResponseRecorder) {
+				require.Equal(t, http.StatusOK, rr.Code)
+				require.True(t, handlerCalled)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := testCase.setup()
+			handlerCalled := false
+			testFilter.Decorate(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				w.WriteHeader(http.StatusOK)
+			})(rr, req)
+			testCase.assertions(handlerCalled, rr)
+		})
+	}
+}


### PR DESCRIPTION
When I originally wrote the webhook receiver for this gateway, I tried to use an HTTP request filter to authenticate the request's signature, but I was unsuccessful at the time because verifying a signature involves reading the request body-- and that's a destructive operation. The act of verifying the signature meant the filter worked, but the payload was gone by the time it hit the handler.

To make things worked, I incorporated authn (signature verification) right into the handler and I never totally felt good about that. (I strongly believe that, architecturally, authn and authz concerns should be "decorative," rather than polluting other logic.)

Well... I've written a few of these gateways now and I've encountered these same circumstances again (working on a Slack gateway). I learned how to handle this the right way-- you can add the body of the request _back_ onto the request after you've read it.

So, this PR is a bit of refactoring to make all of this a little cleaner. There are no functional changes here and I should also note that I've already manually tested this with _real_ github webhooks and everything checks out.