### PR TITLE
chart: add better error msg when brigade api token is missing

### DIFF
--- a/charts/brigade-github-gateway/templates/monitor/secret.yaml
+++ b/charts/brigade-github-gateway/templates/monitor/secret.yaml
@@ -7,4 +7,8 @@ metadata:
     {{- include "gateway.monitor.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.brigade.apiToken }}
   brigadeAPIToken: {{ .Values.brigade.apiToken }}
+  {{- else }}
+    {{ fail "Value MUST be specified for brigade.apiToken" }}
+  {{- end }}

--- a/charts/brigade-github-gateway/templates/receiver/secret.yaml
+++ b/charts/brigade-github-gateway/templates/receiver/secret.yaml
@@ -7,4 +7,8 @@ metadata:
     {{- include "gateway.receiver.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.brigade.apiToken }}
   brigadeAPIToken: {{ .Values.brigade.apiToken }}
+  {{- else }}
+    {{ fail "Value MUST be specified for brigade.apiToken" }}
+  {{- end }}


### PR DESCRIPTION
Signed-off-by: Kent Rancourt <kent.rancourt@microsoft.com>