### PR TITLE
Add support for `ingressClassName` to Helm chart

### DIFF
--- a/charts/brigade-github-gateway/templates/_helpers.tpl
+++ b/charts/brigade-github-gateway/templates/_helpers.tpl
@@ -69,3 +69,22 @@ app.kubernetes.io/component: monitor
 {{- $template := index . 2 }}
 {{- include $template (dict "Chart" (dict "Name" $subchart) "Values" (index $dot.Values $subchart) "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for a networking object.
+*/}}
+{{- define "networking.apiVersion" -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.isStable" -}}
+  {{- eq (include "networking.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+
+{{- define "networking.apiVersion.supportIngressClassName" -}}
+  {{- semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- end -}}

--- a/charts/brigade-github-gateway/templates/receiver/ingress.yaml
+++ b/charts/brigade-github-gateway/templates/receiver/ingress.yaml
@@ -1,9 +1,7 @@
 {{- if .Values.receiver.ingress.enabled }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
-apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+{{- $networkingApiIsStable := eq (include "networking.apiVersion.isStable" .) "true" -}}
+{{- $networkingApiSupportsIngressClassName := eq (include "networking.apiVersion.supportIngressClassName" .) "true" -}}
+apiVersion: {{ template "networking.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "gateway.receiver.fullname" . }}
@@ -15,11 +13,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and (.Values.receiver.ingress.ingressClassName) ($networkingApiSupportsIngressClassName) }}
+  ingressClassName: {{ .Values.receiver.ingress.ingressClassName }}
+  {{- end }}
   rules:
   - host: {{ .Values.receiver.host }}
     http:
       paths:
-      {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+      {{- if $networkingApiIsStable }}
       - pathType: ImplementationSpecific
         path: /
         backend:

--- a/charts/brigade-github-gateway/values.yaml
+++ b/charts/brigade-github-gateway/values.yaml
@@ -121,6 +121,9 @@ receiver:
     ## documentation to customize the behavior of the ingress resource.
     annotations:
       # kubernetes.io/ingress.class: nginx
+    ## From Kubernetes 1.18+ this field is supported in case your ingress controller supports it.
+    ## When set, you do not need to add the ingress class as annotation.
+    ingressClassName:
     tls:
       ## Whether to enable TLS. If true then you MUST do ONE of three things to
       ## ensure the existence of a TLS certificate:


### PR DESCRIPTION
Also rewrite API version handling according to https://github.com/brigadecore/charts/pull/92.

closes #37

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>