### PR TITLE
add more linters

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -2,7 +2,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@br
 
 const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
-const goImg = "brigadecore/go-tools:v0.4.0"
+const goImg = "brigadecore/go-tools:v0.5.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.1.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.4.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.5.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,20 +6,25 @@ run:
 linters:
   disable-all: true
   enable:
+  - bodyclose
   - depguard
   # - dupl
   - errcheck
+  - exportloopref
+  - forcetypeassert
   - goconst
   - gocyclo
   - gofmt
   - goimports
   - golint
+  - gosec
   - govet
   - lll
   # - maligned
   - misspell
   - nakedret
   - prealloc
+  - unconvert
   - unparam
   - unused
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -99,7 +99,7 @@ func createJWT(appID int64, keyPEM []byte) (string, error) {
 		jwt.StandardClaims{
 			IssuedAt:  now.Unix(),
 			ExpiresAt: now.Add(5 * time.Minute).Unix(),
-			Issuer:    strconv.FormatInt(int64(appID), 10),
+			Issuer:    strconv.FormatInt(appID, 10),
 		},
 	).SignedString(key)
 }

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.4.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.5.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/monitor/events_test.go
+++ b/monitor/events_test.go
@@ -376,7 +376,7 @@ func TestMonitorEventInternal(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run(string(testCase.name), func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			err := testCase.monitor.monitorEventInternal(
 				context.Background(),
 				testEventID,
@@ -515,7 +515,7 @@ func TestCreateCheckRun(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run(string(testCase.name), func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			checkRunID, err := testCase.monitor.createCheckRun(
 				context.Background(),
 				testApp,
@@ -659,7 +659,7 @@ func TestUpdateCheckRun(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		t.Run(string(testCase.name), func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			err := testCase.monitor.updateCheckRun(
 				context.Background(),
 				testApp,

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM brigadecore/go-tools:v0.4.0
+FROM brigadecore/go-tools:v0.5.0
 ARG VERSION
 ARG COMMIT
 ENV CGO_ENABLED=0

--- a/receiver/internal/webhooks/service_test.go
+++ b/receiver/internal/webhooks/service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewService(t *testing.T) {
-	s := NewService(
+	s := NewService( // nolint: forcetypeassert
 		// Totally unusable client that is enough to fulfill the dependencies for
 		// this test...
 		&coreTesting.MockEventsClient{

--- a/receiver/internal/webhooks/signature_verification_filter_test.go
+++ b/receiver/internal/webhooks/signature_verification_filter_test.go
@@ -25,7 +25,7 @@ func TestNewSignatureVerificationFilter(t *testing.T) {
 			},
 		},
 	}
-	filter :=
+	filter := // nolint: forcetypeassert
 		NewSignatureVerificationFilter(testConfig).(*signatureVerificationFilter)
 	require.Equal(t, testConfig, filter.config)
 }

--- a/receiver/main.go
+++ b/receiver/main.go
@@ -56,9 +56,7 @@ func main() {
 		router.StrictSlash(true)
 		router.Handle(
 			"/events",
-			http.HandlerFunc( // Make a handler from a function
-				signatureVerificationFilter.Decorate(handler.ServeHTTP),
-			),
+			signatureVerificationFilter.Decorate(handler.ServeHTTP),
 		).Methods(http.MethodPost)
 		router.HandleFunc("/healthz", libHTTP.Healthz).Methods(http.MethodGet)
 		serverConfig, err := serverConfig()


### PR DESCRIPTION
Requires https://github.com/brigadecore/go-tools/pull/16 to be merged and `brigadecore/go-tools:v0.5.0` to be released first, as that image will contain new and updated linters.