### PR TITLE
make multiarch build faster

### DIFF
--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -1,19 +1,23 @@
-FROM brigadecore/go-tools:v0.5.0
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.5.0 as builder
+
 ARG VERSION
 ARG COMMIT
+ARG TARGETOS
+ARG TARGETARCH
 ENV CGO_ENABLED=0
+
 WORKDIR /src
 COPY receiver/ receiver/
 COPY internal/ internal/
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-RUN go build \
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/receiver \
   -ldflags "-w -X github.com/brigadecore/brigade-foundations/version.version=$VERSION -X github.com/brigadecore/brigade-foundations/version.commit=$COMMIT" \
   ./receiver
 
 FROM scratch
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=0 /src/bin/ /brigade-github-gateway/bin/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /src/bin/ /brigade-github-gateway/bin/
 ENTRYPOINT ["/brigade-github-gateway/bin/receiver"]


### PR DESCRIPTION
This PR includes changes that should have been in #45.

Cross-compiling for the target architecture on the native architecture is faster than emulating the target architecture and not cross-compiling.