### PR TITLE
use sdk v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.18.2
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/brigadecore/brigade-foundations v0.2.0
-	github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1
+	github.com/brigadecore/brigade/sdk/v2 v2.0.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-github/v33 v33.0.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2 h1:7Ip0wMmLHLRJdrloD
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/brigadecore/brigade-foundations v0.2.0 h1:pUtIQgN5Qa1I5JjpJOu+9E7J/kXC/QY2fzdGZt/I50I=
 github.com/brigadecore/brigade-foundations v0.2.0/go.mod h1:edMgSJCUgfHN1RNGiiVOTRW4X4VykBLgssgWHPZK7Sg=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1 h1:VVGS/GOA1jSmEXTIOk54rf9GsqCxwosoulrA1OwC2xg=
-github.com/brigadecore/brigade/sdk/v2 v2.0.0-rc.1/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0 h1:RpApjVcSvuwuN5Sdjm4Vw9H5JWaxl/vZA6f3xC+cPp4=
+github.com/brigadecore/brigade/sdk/v2 v2.0.0/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This PR cuts over to using the GA SDK.

fwiw, I do not intend to continue upgrading the SDK every time there is a Brigade release. Now that we're at least using a stable/GA SDK, I will limit further upgrades of this nature to cases where there is true impetus such as a remediated bug a or a new feature we are in need of leveraging.