### PR TITLE
simplify release process

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,7 +1,5 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@brigadecore/brigadier"
 
-const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
-
 const goImg = "brigadecore/go-tools:v0.5.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.1.0"
@@ -16,12 +14,6 @@ class MakeTargetJob extends Job {
     this.primaryContainer.workingDirectory = localPath
     this.primaryContainer.environment = env || {}
     this.primaryContainer.environment["SKIP_DOCKER"] = "true"
-    if (event.worker?.git?.ref) {
-      const matchStr = event.worker.git.ref.match(releaseTagRegex)
-      if (matchStr) {
-        this.primaryContainer.environment["VERSION"] = Array.from(matchStr)[1] as string
-      }
-    }
     this.primaryContainer.command = [ "make" ]
     this.primaryContainer.arguments = targets
   }
@@ -86,18 +78,22 @@ class BuildImageJob extends MakeTargetJob {
 
 // PushImageJob is a specialized job type for publishing Docker images.
 class PushImageJob extends BuildImageJob {
-  constructor(target: string, event: Event) {
-    super(target, event, {
+  constructor(target: string, event: Event, version?: string) {
+    const env = {
       "DOCKER_ORG": event.project.secrets.dockerhubOrg,
       "DOCKER_USERNAME": event.project.secrets.dockerhubUsername,
       "DOCKER_PASSWORD": event.project.secrets.dockerhubPassword
-    })
+    }
+    if (version) {
+      env["VERSION"] = version
+    }
+    super(target, event, env)
   }
 }
 
 // A map of all jobs. When a check_run:rerequested event wants to re-run a
 // single job, this allows us to easily find that job by name.
-const jobs: {[key: string]: (event: Event) => Job } = {}
+const jobs: {[key: string]: (event: Event, version?: string) => Job } = {}
 
 // Basic tests:
 
@@ -130,8 +126,8 @@ const buildReceiverJob = (event: Event) => {
 jobs[buildReceiverJobName] = buildReceiverJob
 
 const pushReceiverJobName = "push-receiver"
-const pushReceiverJob = (event: Event) => {
-  return new PushImageJob(pushReceiverJobName, event)
+const pushReceiverJob = (event: Event, version?: string) => {
+  return new PushImageJob(pushReceiverJobName, event, version)
 }
 jobs[pushReceiverJobName] = pushReceiverJob
 
@@ -142,14 +138,15 @@ const buildMonitorJob = (event: Event) => {
 jobs[buildMonitorJobName] = buildMonitorJob
 
 const pushMonitorJobName = "push-monitor"
-const pushMonitorJob = (event: Event) => {
-  return new PushImageJob(pushMonitorJobName, event)
+const pushMonitorJob = (event: Event, version?: string) => {
+  return new PushImageJob(pushMonitorJobName, event, version)
 }
 jobs[pushMonitorJobName] = pushMonitorJob
 
 const publishChartJobName = "publish-chart"
-const publishChartJob = (event: Event) => {
+const publishChartJob = (event: Event, version: string) => {
   return new MakeTargetJob([publishChartJobName], helmImg, event, {
+    "VERSION": version,
     "HELM_REGISTRY": event.project.secrets.helmRegistry || "ghcr.io",
     "HELM_ORG": event.project.secrets.helmOrg,
     "HELM_USERNAME": event.project.secrets.helmUsername,
@@ -197,29 +194,19 @@ events.on("brigade.sh/github", "check_run:rerequested", async event => {
   throw new Error(`No job found with name: ${jobName}`)
 })
 
-// Pushing new commits to any branch in github triggers a check suite. Such
-// events are already handled above. Here we're only concerned with the case
-// wherein a new TAG has been pushed-- and even then, we're only concerned with
-// tags that look like a semantic version and indicate a formal release should
-// be performed.
-events.on("brigade.sh/github", "push", async event => {
-  const matchStr = event.worker.git.ref.match(releaseTagRegex)
-  if (matchStr) {
-    // This is an official release with a semantically versioned tag
-    await new SerialGroup(
-      new ConcurrentGroup(
-        pushReceiverJob(event),
-        pushMonitorJob(event)
-      ),
-      // Chart publishing is deliberately run only after all image pushes above
-      // have succeeded. We don't want any possibility of publishing a chart
-      // that references images that failed to push (or simply haven't
-      // finished pushing).
-      publishChartJob(event)
-    ).run()
-  } else {
-    console.log(`Ref ${event.worker.git.ref} does not match release tag regex (${releaseTagRegex}); not releasing.`)
-  }
+events.on("brigade.sh/github", "release:published", async event => {
+  const version = JSON.parse(event.payload).release.tag_name
+  await new SerialGroup(
+    new ConcurrentGroup(
+      pushReceiverJob(event, version),
+      pushMonitorJob(event, version)
+    ),
+    // Chart publishing is deliberately run only after all image pushes above
+    // have succeeded. We don't want any possibility of publishing a chart
+    // that references images that failed to push (or simply haven't
+    // finished pushing).
+    publishChartJob(event, version)
+  ).run()
 })
 
 events.process()

--- a/.brigade/project.yaml
+++ b/.brigade/project.yaml
@@ -13,7 +13,7 @@ spec:
     - check_run:rerequested
     - check_suite:requested
     - check_suite:rerequested
-    - push
+    - release:published
   workerTemplate:
     git:
       cloneURL: https://github.com/brigadecore/brigade-github-gateway.git


### PR DESCRIPTION
While working on #59, I've stumbled on this easier/cleaner way to handle releases.

Note that we probably have to _do_ a release to validate this all works exactly as expected.

I plan to release v0.5.0 as soon as this PR and related pre-release bumps are merged.

__EDIT:__ I did test this release process on a test repo and it worked very well.