### PR TITLE
add job label to ci:job_requested events

### DIFF
--- a/receiver/internal/webhooks/ci_cd.go
+++ b/receiver/internal/webhooks/ci_cd.go
@@ -1,7 +1,10 @@
 package webhooks
 
 import (
+	"strings"
+
 	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/google/go-github/v33/github"
 )
 
 func (s *service) getCICDEvent(event core.Event) *core.Event {
@@ -18,6 +21,19 @@ func (s *service) getCICDEvent(event core.Event) *core.Event {
 	// addition to the original check_run:rerequested event.
 	case "check_run:rerequested":
 		ciCDEvent.Type = "ci:job_requested"
+		// We should always be able to parse this. If this were not parsable, we
+		// would have encountered an error long before this function was called.
+		// nolint: errcheck
+		webhook, _ := github.ParseWebHook("check_run", []byte(event.Payload))
+		// If we're already emitting a check_run:rerequested, the original webhook
+		// MUST have been a *github.CheckRunEvent, so we can safely assume this
+		// type assertion always succeeds.
+		// nolint: forcetypeassert
+		checkRunWebHook := webhook.(*github.CheckRunEvent)
+		// Job names from this gateway are always of the form <project:job>
+		qualifiedJobName := checkRunWebHook.GetCheckRun().GetName()
+		jobNameTokens := strings.SplitN(qualifiedJobName, ":", 2)
+		ciCDEvent.Labels["job"] = jobNameTokens[1]
 	// For consistency with the above, we emit a cd:pipeline_requested event in
 	// addition to the original release:published event.
 	case "release:published":

--- a/receiver/internal/webhooks/service_test.go
+++ b/receiver/internal/webhooks/service_test.go
@@ -188,6 +188,14 @@ func TestHandle(t *testing.T) {
 				require.Equal(t, testQualifiers, event.Qualifiers)
 				require.Equal(
 					t,
+					map[string]string{
+						"appID": "42",
+						"job":   "bar",
+					},
+					event.Labels,
+				)
+				require.Equal(
+					t,
 					core.GitDetails{
 						Commit: testSHA,
 						Ref:    testBranch,


### PR DESCRIPTION
The documentation says we add a "job" label to `ci:job_requested` events, but we were not.