### PR TITLE
Dockerfiles: cache go mods in their own layer

### DIFF
--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -7,10 +7,11 @@ ARG TARGETARCH
 ENV CGO_ENABLED=0
 
 WORKDIR /src
-COPY monitor/ monitor/
-COPY internal/ internal/
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN go mod download
+COPY monitor/ monitor/
+COPY internal/ internal/
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/monitor \

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -7,10 +7,11 @@ ARG TARGETARCH
 ENV CGO_ENABLED=0
 
 WORKDIR /src
-COPY receiver/ receiver/
-COPY internal/ internal/
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN go mod download
+COPY receiver/ receiver/
+COPY internal/ internal/
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/receiver \


### PR DESCRIPTION
This PR caches resolved dependencies in their own layer to improve build time when built repeatedly -- i.e. during dev.