### PR TITLE
chart: add note about brigade version to values.yaml

### DIFF
--- a/charts/brigade-github-gateway/values.yaml
+++ b/charts/brigade-github-gateway/values.yaml
@@ -201,6 +201,9 @@ monitor:
       ## fail, will be reported as failures. When set to true, failed jobs will
       ## be reported with a neutral status. This is defaulted to false for
       ## backwards compatibility, but it is recommended to set this to true.
+      ##
+      ## Note that Brigade v2.4.0+ is required for this feature to work
+      ## correctly.
       reportFallibleJobFailuresAsNeutral: false
 
   resources: {}


### PR DESCRIPTION
This note seemed like a wise thing to add to `values.yaml`.

With older versions of Brigade, this won't error, but the information that would allow a neutral response to be sent will never be included int he response when the gateway's monitor component requests event/job info from the API server.