### PR TITLE
remove inaccurate section of docs

### DIFF
--- a/docs/EVENT_REFERENCE.md
+++ b/docs/EVENT_REFERENCE.md
@@ -35,18 +35,10 @@ subject to a few very simple rules:
 1. For any webhook that is indicative of activity involving not only a specific
    repository, but also some specific ref (branch or tag) or commit (identified
    by SHA), this gateway copies those details from the webhook's JSON payload
-   and:
-   
-    1. Promotes them to the corresponding event's `git.ref` and/or `git.commit`
-       fields. By doing so, Brigade is enabled to locate specific code
-       referenced by the webhook/event. The importance of this cannot be
-       understated, as it is what permits Brigade to be used for implementing
-       CI/CD pipelines.
-
-    2. Promotes the ref to the `ref` label on the corresponding event. This
-       permits projects to, for instance, subscribe only to events relating
-       to a specific branch. Read more about labels
-       [here](https://docs.brigade.sh/topics/project-developers/events/#labels).
+   and promotes them to the corresponding event's `git.ref` and/or `git.commit`
+   fields. By doing so, Brigade is enabled to locate specific code referenced by
+   the webhook/event. The importance of this cannot be understated, as it is
+   what permits Brigade to be used for implementing CI/CD pipelines.
 
 1. If this gateway is able to infer that a webhook pertains only to a _specific_
    Brigade project, this information will be included in the corresponding


### PR DESCRIPTION
This PR removes an inaccurate section of the documentation.

No such thing as what is described actually happens.

Rather than remove this bit of docs, I was tempted to add the feature as described and then realized that, as described, it probably doesn't make sense.

While it certainly would make sense to narrow event subscriptions based on a branch -- for instance, expressing, that you want to subscribe to anything having to do with branch `v3` -- simply "promoting" whatever, if anything, is in an event's `Git.Ref` field (as described) wouldn't help to achieve that. It would work for a merge event, perhaps, but for a pull request, for instance,`Git.Ref` reflects the _source_ branch and not the _target_ branch. So if you were interested in things that would tentatively be merged _into_ `v3`, you'd miss that event.

There's a sensible way to add this functionality, but it will require great care to extract this detail from the correct field _for each type of webhook_ and I don't think it should be rushed.

I'll open a separate issue, and in the meantime, I think it's best to remove this from the docs.